### PR TITLE
Handle missing DATABASE_URL and document env requirements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for Logos Journal
+# DATABASE_URL is required for database migrations and CI workflows.
+# NODE_ENV can be set to 'development' locally.
+DATABASE_URL=postgres://user:password@localhost:5432/logos
+NODE_ENV=development

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -57,7 +57,7 @@ The deployment configuration is now fully working with the standard npm scripts.
 - Users need their own OpenAI API key for full functionality
 - PostgreSQL database connection (optional - falls back to in-memory storage)
 - No additional setup required - app guides users through API key setup
-- Environment variables: `NODE_ENV=production`, `DATABASE_URL` (optional)
+- Environment variables: `NODE_ENV=production`, `DATABASE_URL` (required for migrations or persistent storage)
 
 ### Cost Considerations
 - Autoscale deployment scales to zero when idle (cost-effective)

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -148,5 +148,5 @@ This app requires a Node.js server for the Express backend and database connecti
 
 ## Environment Variables
 Required for production deployment:
-- `DATABASE_URL` - PostgreSQL connection string (optional, falls back to in-memory)
+- `DATABASE_URL` - PostgreSQL connection string (required for migrations and CI, optional for in-memory fallback)
 - `NODE_ENV` - Set to "production" for production builds

--- a/README.md
+++ b/README.md
@@ -64,14 +64,11 @@ npm install
 ```
 
 3. **Set up environment variables**
-Create a `.env` file in the root directory:
+Copy the example file and update the values:
 ```bash
-# Database (optional)
-DATABASE_URL=your_postgresql_connection_string
-
-# Development settings
-NODE_ENV=development
+cp .env.example .env
 ```
+`DATABASE_URL` is required for database migrations and CI workflows but optional for basic local development (an in-memory store is used when absent).
 
 4. **Start the application**
 ```bash
@@ -159,6 +156,7 @@ npm run dev          # Start development server
 npm run build        # Build for production
 npm run preview      # Preview production build
 npm run type-check   # Run TypeScript checking
+npm run db:push      # Run database migrations (requires DATABASE_URL)
 ```
 
 ### Environment Configuration
@@ -167,6 +165,8 @@ The application automatically detects the environment and configures itself acco
 
 - **Development**: Hot reload, detailed error messages, in-memory storage fallback
 - **Production**: Optimized builds, error handling, database persistence
+
+For continuous integration workflows, ensure a `DATABASE_URL` value is provided so that database migrations and checks can run.
 
 ## API Integration
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "node scripts/require-database-url.mjs && drizzle-kit push"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/require-database-url.mjs
+++ b/scripts/require-database-url.mjs
@@ -1,4 +1,3 @@
-import { defineConfig } from "drizzle-kit";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -6,11 +5,11 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-function loadDatabaseUrl(): string | undefined {
+function resolveDatabaseUrl() {
   if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
 
-  for (const file of [".env", ".env.example"]) {
-    const fullPath = path.join(__dirname, file);
+  for (const file of ["../.env", "../.env.example"]) {
+    const fullPath = path.resolve(__dirname, file);
     if (fs.existsSync(fullPath)) {
       const content = fs.readFileSync(fullPath, "utf-8");
       const match = content.match(/^DATABASE_URL=(.+)$/m);
@@ -23,15 +22,7 @@ function loadDatabaseUrl(): string | undefined {
   return undefined;
 }
 
-const databaseUrl = loadDatabaseUrl();
-
-export default databaseUrl
-  ? defineConfig({
-      out: "./migrations",
-      schema: "./shared/schema.ts",
-      dialect: "postgresql",
-      dbCredentials: {
-        url: databaseUrl,
-      },
-    })
-  : {};
+if (!resolveDatabaseUrl()) {
+  console.error("Error: DATABASE_URL is required for this operation.");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Gracefully load `DATABASE_URL` for Drizzle config from `.env` or `.env.example`, exporting an empty config when no value exists.
- Add a pre-migration script and update `db:push` to require `DATABASE_URL` before running Drizzle migrations.
- Document required environment variables for development, CI, and production, and include a sample `.env.example`.

## Testing
- `node scripts/require-database-url.mjs`
- `npm test` (fails: Missing script "test")
- `npm run check`
- `npx tsx -e "import('./drizzle.config.ts').then(m => console.log(m.default))"`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a75b4ec8320b3067828fdb8a387