### PR TITLE
feat: use AES-GCM for local API key storage

### DIFF
--- a/client/src/lib/security.ts
+++ b/client/src/lib/security.ts
@@ -1,34 +1,60 @@
-// Simple encryption for localStorage API keys
-// Note: This is for user comfort, not true security against determined attackers
+// Utility functions for API key handling using AES-GCM encryption
+// This provides basic protection for keys stored in localStorage
 
-const ENCRYPTION_KEY = 'logos_journal_2024';
+const ENCRYPTION_KEY_STORAGE = 'api_key_encryption_key';
+const API_KEY_IV_STORAGE = 'api_key_iv';
 
-export function encryptApiKey(apiKey: string): string {
+function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((b) => binary += String.fromCharCode(b));
+  return btoa(binary);
+}
+
+function base64ToBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function getCryptoKey(): Promise<CryptoKey> {
+  const stored = localStorage.getItem(ENCRYPTION_KEY_STORAGE);
+  if (stored) {
+    const keyData = base64ToBuffer(stored);
+    return crypto.subtle.importKey('raw', keyData, 'AES-GCM', true, ['encrypt', 'decrypt']);
+  }
+  const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
+  const exported = await crypto.subtle.exportKey('raw', key);
+  localStorage.setItem(ENCRYPTION_KEY_STORAGE, bufferToBase64(exported));
+  return key;
+}
+
+export async function encryptApiKey(apiKey: string): Promise<string> {
   try {
-    // Simple XOR encryption - enough to prevent casual viewing
-    let encrypted = '';
-    for (let i = 0; i < apiKey.length; i++) {
-      encrypted += String.fromCharCode(
-        apiKey.charCodeAt(i) ^ ENCRYPTION_KEY.charCodeAt(i % ENCRYPTION_KEY.length)
-      );
-    }
-    return btoa(encrypted); // Base64 encode
+    const key = await getCryptoKey();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(apiKey);
+    const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+    localStorage.setItem(API_KEY_IV_STORAGE, bufferToBase64(iv));
+    return bufferToBase64(encrypted);
   } catch (error) {
     console.warn('Encryption failed, storing as-is');
     return apiKey;
   }
 }
 
-export function decryptApiKey(encryptedKey: string): string {
+export async function decryptApiKey(encryptedKey: string): Promise<string> {
   try {
-    const encrypted = atob(encryptedKey); // Base64 decode
-    let decrypted = '';
-    for (let i = 0; i < encrypted.length; i++) {
-      decrypted += String.fromCharCode(
-        encrypted.charCodeAt(i) ^ ENCRYPTION_KEY.charCodeAt(i % ENCRYPTION_KEY.length)
-      );
-    }
-    return decrypted;
+    const key = await getCryptoKey();
+    const ivBase64 = localStorage.getItem(API_KEY_IV_STORAGE);
+    if (!ivBase64) return encryptedKey;
+    const iv = new Uint8Array(base64ToBuffer(ivBase64));
+    const encrypted = base64ToBuffer(encryptedKey);
+    const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, encrypted);
+    return new TextDecoder().decode(decrypted);
   } catch (error) {
     console.warn('Decryption failed, using as-is');
     return encryptedKey;
@@ -40,21 +66,23 @@ export function maskApiKey(apiKey: string): string {
   return `sk-••••${apiKey.slice(-4)}`;
 }
 
-export function storeApiKey(apiKey: string): void {
-  const encrypted = encryptApiKey(apiKey);
+export async function storeApiKey(apiKey: string): Promise<void> {
+  const encrypted = await encryptApiKey(apiKey);
   localStorage.setItem('openai_api_key_encrypted', encrypted);
   localStorage.setItem('api_key_stored_at', new Date().toISOString());
 }
 
-export function getStoredApiKey(): string | null {
+export async function getStoredApiKey(): Promise<string | null> {
   const encrypted = localStorage.getItem('openai_api_key_encrypted');
   if (!encrypted) return null;
-  return decryptApiKey(encrypted);
+  return await decryptApiKey(encrypted);
 }
 
 export function clearStoredApiKey(): void {
   localStorage.removeItem('openai_api_key_encrypted');
   localStorage.removeItem('api_key_stored_at');
+  localStorage.removeItem(ENCRYPTION_KEY_STORAGE);
+  localStorage.removeItem(API_KEY_IV_STORAGE);
 }
 
 export function getApiKeyStoredDate(): Date | null {
@@ -65,3 +93,4 @@ export function getApiKeyStoredDate(): Date | null {
 export function hasStoredApiKey(): boolean {
   return !!localStorage.getItem('openai_api_key_encrypted');
 }
+

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -17,11 +17,11 @@ import {
   DialogTitle,
   DialogDescription 
 } from "@/components/ui/dialog";
-import { 
-  storeApiKey, 
-  getStoredApiKey, 
-  hasStoredApiKey, 
-  clearStoredApiKey 
+import {
+  storeApiKey,
+  getStoredApiKey,
+  hasStoredApiKey,
+  clearStoredApiKey
 } from "@/lib/security";
 import { SecurityBadge } from "@/components/ui/security-badge";
 import { 
@@ -575,12 +575,14 @@ export default function Home() {
 
   // Load API key from secure storage on mount
   useEffect(() => {
-    const storedKey = getStoredApiKey();
-    if (storedKey) {
-      setApiKey(storedKey);
-      // If user already has a stored API key, they can skip directly to questions
-      // but still allow them to see the API setup screen to manage their key
-    }
+    (async () => {
+      const storedKey = await getStoredApiKey();
+      if (storedKey) {
+        setApiKey(storedKey);
+        // If user already has a stored API key, they can skip directly to questions
+        // but still allow them to see the API setup screen to manage their key
+      }
+    })();
   }, []);
 
   const validateAndSaveApiKey = async () => {
@@ -614,7 +616,7 @@ export default function Home() {
       });
       
       if (testResponse.ok) {
-        storeApiKey(apiKey);
+        await storeApiKey(apiKey);
         generateSessionQuote(); // Set the session quote before starting questions
         await generateQuestions();
       } else {
@@ -928,7 +930,7 @@ export default function Home() {
     setCurrentStep("apiSetup");
   };
 
-  const resetToHome = () => {
+  const resetToHome = async () => {
     setCurrentStep("welcome");
     setCurrentQuestionIndex(0);
     setResponses({});
@@ -946,7 +948,7 @@ export default function Home() {
     setSessionQuote(null); // Reset session quote for new reflection
     
     // Keep the API key but reset everything else
-    const storedKey = getStoredApiKey();
+    const storedKey = await getStoredApiKey();
     if (storedKey) {
       setApiKey(storedKey);
     }


### PR DESCRIPTION
## Summary
- replace XOR-based API key storage with AES-GCM encryption using SubtleCrypto
- adapt client logic to async API key storage and retrieval

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd97781b6c8320a31a3140e4360dc2